### PR TITLE
feat: mark listing enquiry as read (HOM-99)

### DIFF
--- a/src/features/messages/EnquiryMessageInfo.tsx
+++ b/src/features/messages/EnquiryMessageInfo.tsx
@@ -1,8 +1,7 @@
-import React from "react";
-import { EnquiryData } from "./types";
-import Link from "next/link";
+import { clientUrl } from "lib/endpoints";
 import { reFormatString } from "lib/utils/utils";
-import { siteUrl } from "lib/endpoints";
+import Link from "next/link";
+import { EnquiryData } from "./types";
 
 type EnquiryMessageInfoProps = {
   enquiryData: EnquiryData;
@@ -73,7 +72,7 @@ export default function EnquiryMessageInfo({
               href={`/listings/user-listings/${enquiryData.listingId}`}
               className="text-blue-600 underline"
             >
-              {`${siteUrl}/listings/user-listings/${enquiryData.listingId}`}
+              {`${clientUrl}/listings/user-listings/${enquiryData.listingId}`}
             </Link>
           </h2>
         </div>

--- a/src/features/messages/EnquiryMessageItem.tsx
+++ b/src/features/messages/EnquiryMessageItem.tsx
@@ -2,19 +2,33 @@ import React from "react";
 
 import { EnquiryMessageItemProps } from "./types";
 import { formatDate } from "lib/utils/utils";
+import clsx from "clsx";
 
 export default function MessageItem({
   date,
   messageString,
   senderEmail,
+  isRead,
 }: EnquiryMessageItemProps) {
   return (
-    <div className="border mb-2 border-gray-300 lg:flex px-3 justify-between items-center flex-wrap py-4 rounded-md">
+    <div
+      className={clsx(
+        "border mb-2 border-gray-300 lg:flex px-3 justify-between items-center flex-wrap py-4 rounded-md",
+        isRead ? "bg-transparent" : "bg-green-100"
+      )}
+    >
       <div className="basis-3/12">
         <p className="font-hanken-black">{senderEmail}</p>
         <p className="font-hanken-semibold md:block ">{formatDate(date)}</p>
       </div>
-      <p className="basis-9/12">{messageString}</p>
+      <p
+        className={clsx(
+          "basis-9/12",
+          isRead ? "font-hanken-regular" : "font-hanken-black"
+        )}
+      >
+        {messageString}
+      </p>
     </div>
   );
 }

--- a/src/features/messages/EnquiryMessages.tsx
+++ b/src/features/messages/EnquiryMessages.tsx
@@ -6,15 +6,19 @@ import ControlButtons from "shared/ControlButtons";
 import LoadingScreen from "shared/LoadingScreen";
 import ErrorMessage from "shared/ErrorMessage";
 import Link from "next/link";
+import useMarkAsRead from "hooks/useMarkAsRead";
 
 export default function Messages() {
   const [page, setPage] = useState(1);
   const [size, setSize] = useState(10);
+
   const {
     listingEnquiriesData,
     listingEnquiriesStatus,
     listingEnquiriesError,
   } = useGetListingEnquiries(page, size);
+
+  const { mutateMarkAsRead } = useMarkAsRead();
 
   const messages = listingEnquiriesData?.data.items;
 
@@ -26,6 +30,11 @@ export default function Messages() {
 
   function handleFetchPreviousData() {
     setPage((prevPage) => Math.max(prevPage - 1, 0));
+  }
+
+  function handleMarkAsRead(enquiryMessageId: string, isRead: boolean) {
+    if (isRead) return;
+    mutateMarkAsRead(enquiryMessageId);
   }
   return (
     <div>
@@ -47,12 +56,17 @@ export default function Messages() {
       )}
       <div className="pb-10">
         {messages?.map((message, index) => (
-          <Link href={`/messages/${message.id}`} key={message.id}>
+          <Link
+            href={`/messages/${message.id}`}
+            key={message.id}
+            onClick={() => handleMarkAsRead(message.id, message.read)}
+          >
             <EnquiryMessageItem
               key={index}
               date={message.createdAt}
               messageString={message.message.substring(0, 150)}
               senderEmail={message.email}
+              isRead={message.read}
             />
           </Link>
         ))}

--- a/src/features/messages/types.ts
+++ b/src/features/messages/types.ts
@@ -4,6 +4,7 @@ export type EnquiryMessageItemProps = {
   date: string;
   messageString: string;
   senderEmail: string;
+  isRead: boolean;
 };
 
 export type EnquiryMessageProps = {
@@ -29,6 +30,7 @@ export type EnquiryData = {
   listingId: string;
   agentId: string;
   createdAt: string;
+  read: boolean;
 };
 
 export interface EnquiryMessageDetailResponse extends BaseResponse {

--- a/src/hooks/useMarkAsRead.ts
+++ b/src/hooks/useMarkAsRead.ts
@@ -1,0 +1,23 @@
+import { useMutation } from "@tanstack/react-query";
+import { HOME_360_LISTING_ENQUIRY_BASE } from "lib/endpoints";
+import errorHandler from "lib/utils/errorHandler";
+import requestHandler from "lib/utils/requestHandler";
+
+export default function useMarkAsRead() {
+  const { data, error, status, mutate } = useMutation({
+    mutationKey: ["mark_as_read"],
+    mutationFn: (enquiryMessageId: string) =>
+      requestHandler(
+        `${HOME_360_LISTING_ENQUIRY_BASE}/${enquiryMessageId}/read`,
+        {
+          method: "PATCH",
+        }
+      ),
+  });
+  return {
+    markAsReadData: data?.data,
+    markAsReadStatus: status,
+    markAsReadError: errorHandler(error),
+    mutateMarkAsRead: mutate,
+  };
+}

--- a/src/hooks/useSubmitEnquiryForm.ts
+++ b/src/hooks/useSubmitEnquiryForm.ts
@@ -7,7 +7,7 @@ import {
   ListingEnquiryResponse,
 } from "features/listings/types";
 
-import { HOME_360_CREATE_LISTING_ENQUIRY } from "lib/endpoints";
+import { HOME_360_LISTING_ENQUIRY_BASE } from "lib/endpoints";
 import errorHandler from "lib/utils/errorHandler";
 import requestHandler from "lib/utils/requestHandler";
 
@@ -20,7 +20,7 @@ export function useSubmitEnquiryForm() {
     mutationKey: ["enquiry form"],
     networkMode: "always",
     mutationFn: (enquiryData) =>
-      requestHandler(HOME_360_CREATE_LISTING_ENQUIRY, {
+      requestHandler(HOME_360_LISTING_ENQUIRY_BASE, {
         method: "POST",
         data: enquiryData,
         headers: {

--- a/src/lib/endpoints/index.ts
+++ b/src/lib/endpoints/index.ts
@@ -1,6 +1,6 @@
 import { getEnvironment } from "lib/utils/utils";
 
-export const siteUrl =
+export const clientUrl =
   getEnvironment() === "Development"
     ? process.env.NEXT_PUBLIC_DEV_URL
     : process.env.NEXT_PUBLIC_PROD_URL;
@@ -24,8 +24,9 @@ export const HOME_360_RESEND_VERIFICATION_TOKEN = `${serverUrl}/auth/resend-veri
 
 export const HOME_360_FETCH_USERLISTINGS = `${serverUrl}/userListings`;
 export const HOME_360__DELETE_LISTING = `${serverUrl}/listings`;
-export const HOME_360_CREATE_LISTING_ENQUIRY = `${serverUrl}/listing-enquiry`;
+export const HOME_360_LISTING_ENQUIRY_BASE = `${serverUrl}/listing-enquiry`;
 export const HOME_360_GET_LISTING_ENQUIRIES = `${serverUrl}/listing-enquiries`;
+
 //================================INTERNALL ENDPOINTS================
 export const INTERNAL_LOGIN_API = "/api/auth/login";
 export const INTERNAL_LOGOUT_API = "/api/auth/logout";

--- a/src/lib/utils/axiosInstance.ts
+++ b/src/lib/utils/axiosInstance.ts
@@ -54,7 +54,6 @@ axiosClient.interceptors.response.use(
             throw new Error("No refresh token available");
           }
 
-          console.log("user: ", user);
           const result = await axios.post<RefreshTokenTokenResponse>(
             `${serverUrl}/auth/refreshToken`,
             {


### PR DESCRIPTION
## What does this PR do?
* Marks enquiry message as read

## Description of tasks to be completed
* Integrate with endpoint to mark as read
* Add styles to visually differentiate read from unread

##  How should this be manually tested?
* Clone the repo
* Open a terminal on your PC and run git clone
* cd into the project directory and run yarn install
* Run yarn dev to start the server
* Open a browser and navigate to http://localhost:3000/
* Click on the login link and proceed to enter login credentials
* On the dashboard click on messages link on the sidebar
* Click on any enquiry message to mark as read

## What are the relevant Jira board stories?
[HOM-99](https://wasiu-dev.atlassian.net/jira/software/projects/HOM/boards/2?selectedIssue=HOM-99)
Ref #23 

[HOM-99]: https://wasiu-dev.atlassian.net/browse/HOM-99?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ