### PR TITLE
feat: integrate post views endpoint (HOM-147)

### DIFF
--- a/src/features/listings/listingDetails/ListingDetailContainer.tsx
+++ b/src/features/listings/listingDetails/ListingDetailContainer.tsx
@@ -1,32 +1,48 @@
 import useGetListingDetail from "hooks/useGetListingDetail";
 import ErrorMessage from "shared/ErrorMessage";
 import ListingDetail from "./ListingDetail";
+import { useEffect } from "react";
+import usePostListingView from "hooks/usePostListingView";
+import LoadingScreen from "shared/LoadingScreen";
 
 export type ListingInfoProps = { listingId: string };
 
 export default function ListingDetailContainer({
   listingId,
-}: {
-  listingId: string;
-}) {
+}: ListingInfoProps) {
   const { listingDetailData, listingDetailError, isLoadingListingDetail } =
     useGetListingDetail(listingId);
+  const { mutateListingView } = usePostListingView();
 
-  if (listingDetailError) {
-    return <ErrorMessage error={listingDetailError.message} />;
-  }
+  useEffect(() => {
+    const now = new Date();
+    const localISOString = now.toISOString().slice(0, -1);
+    const storedListings = sessionStorage.getItem("viewed-listings");
+    const viewedListings: string[] = storedListings
+      ? JSON.parse(storedListings)
+      : [];
 
-  if (isLoadingListingDetail) {
-    return <h1>Loading.......</h1>;
-  }
+    if (!viewedListings.includes(listingId)) {
+      mutateListingView({ listingId, timestamp: localISOString });
+      viewedListings.push(listingId);
+      sessionStorage.setItem("viewed-listings", JSON.stringify(viewedListings));
+    }
+  }, [listingId, mutateListingView]);
+
   return (
     <div className="">
       <div className="basis-2/3">
-        <ListingDetail
-          listingData={listingDetailData?.data.listing!}
-          listingAgent={listingDetailData?.data.agentInfo!}
-          isLoading={isLoadingListingDetail}
-        />
+        {isLoadingListingDetail && <LoadingScreen />}
+        {listingDetailError && (
+          <ErrorMessage error={listingDetailError.message} />
+        )}
+        {listingDetailData?.status === "OK" && (
+          <ListingDetail
+            listingData={listingDetailData?.data.listing!}
+            listingAgent={listingDetailData?.data.agentInfo!}
+            isLoading={isLoadingListingDetail}
+          />
+        )}
       </div>
     </div>
   );

--- a/src/hooks/usePostListingView.ts
+++ b/src/hooks/usePostListingView.ts
@@ -1,0 +1,26 @@
+import { useMutation } from "@tanstack/react-query";
+import { HOME_360_POST_LISTING_VIEW } from "lib/endpoints";
+import requestHandler from "lib/utils/requestHandler";
+
+type ListingViewParams = {
+  listingId: string;
+  timestamp: string;
+};
+
+export default function usePostListingView() {
+  const { data, status, error, mutate } = useMutation({
+    mutationKey: ["post_listing_view"],
+    mutationFn: ({ listingId, timestamp }: ListingViewParams) =>
+      requestHandler(HOME_360_POST_LISTING_VIEW, {
+        method: "POST",
+        data: {
+          listingId,
+          timestamp,
+        },
+      }),
+    networkMode: "online",
+  });
+  return {
+    mutateListingView: mutate,
+  };
+}

--- a/src/lib/endpoints/index.ts
+++ b/src/lib/endpoints/index.ts
@@ -21,6 +21,7 @@ export const HOME_360_LISTING_BASE_API = `${serverUrl}/listings`;
 export const HOME_360_SEARCH_LISTINGS_API = `${serverUrl}/listings/search`;
 export const HOME_360_FETCH_USERLISTINGS = `${serverUrl}/listings/userListings`;
 export const HOME_360_FETCH_LISTING_STATS = `${serverUrl}/listings/listing-statistics`;
+export const HOME_360_POST_LISTING_VIEW = `${serverUrl}/listing-views`;
 
 export const HOME_360_LISTING_ENQUIRY_BASE = `${serverUrl}/listing-enquiries`;
 export const HOME_360_GET_LISTING_ENQUIRIES = `${serverUrl}/listing-enquiries`;


### PR DESCRIPTION
## What does this PR do?
* Integrates endpoint for saving listings views

## Description of task to be completed
* Integrate the endpoint for saving listing views into the listing detail component.

## How can this be manually tested?
* Clone the repo
* Open a terminal on your PC and run `git clone <repo-url>`
* `cd` into the project directory and run `yarn install`
* Run `yarn dev` to start the server
* Open a browser and navigate to `http://localhost:3000`
* Open the brower developer tools and navigate to the `Network` tab
* Search for a listing
* Click on one of the result 
* Check network tab for a `POST` request sent to `http://localhost:8080/api/v1/listing-views`
* Navigate to `Application` tab of the developer tools and click on `Session Storage`, then click on  `http://localhost:3000` addreses, you should see an array of viewed listings.


## What are the relevant Jira board stories?
[HOM-147](https://wasiu-dev.atlassian.net/jira/software/projects/HOM/boards/2?selectedIssue=HOM-147)

[HOM-147]: https://wasiu-dev.atlassian.net/browse/HOM-147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ