### PR TITLE
refactor: refactor PR automation tool (HOM-181)

### DIFF
--- a/.github/workflows/ai-pr-filler.yml
+++ b/.github/workflows/ai-pr-filler.yml
@@ -53,23 +53,64 @@ jobs:
            ':(exclude)public/fonts' \
           ) > pr.diff
 
+      - name: Skip if PR already edited by humans
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr view ${{ github.event.pull_request.number }} \
+            --json body -q .body > current_body.txt
+
+          # Normalize line endings
+          tr -d '\r' < current_body.txt > current_body.norm.txt
+          tr -d '\r' < .github/pull_request_template.md > template.norm.txt
+
+          if ! diff -q current_body.norm.txt template.norm.txt >/dev/null; then
+            echo "PR body was already edited by a human. Skipping AI update."
+            exit 0
+          fi
+
       - name: Generate PR Body
         id: generate-body
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
         run: |
+          # collect commits
           COMMITS=$(git log origin/${{ github.base_ref }}..HEAD --pretty=format:%s)
-          export COMMITS
+
+          # persist env for node
+          echo "COMMITS<<EOF" >> $GITHUB_ENV
+          echo "$COMMITS" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+
+          echo "PR_TITLE<<EOF" >> $GITHUB_ENV
+          echo "${{ github.event.pull_request.title }}" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+
           # Use node to run the script, and capture output to a file
           node scripts/ai-pr-filler.mjs pr.diff > pr_body.txt
 
-      - name: Update PR Description
+      - name: Post PR description suggestion
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          # Only update if the body isn't empty (sanity check)
-          if [ -s pr_body.txt ]; then
-            gh pr edit ${{ github.event.pull_request.number }} --body-file pr_body.txt
-          else
-            echo "Generated PR body is empty, skipping update."
+          if [ ! -s pr_body.txt ]; then
+            echo "Generated PR body is empty, skipping comment."
+            exit 0
           fi
+
+          {
+            echo "🤖 **Suggested PR description**"
+            echo ""
+            echo "_You can copy and paste this into the PR description if it looks good._"
+            echo ""
+            echo "<details>"
+            echo "<summary>Show suggested description</summary>"
+            echo ""
+            echo '```markdown'
+            cat pr_body.txt
+            echo '```'
+            echo ""
+            echo "</details>"
+          } > pr_comment.txt
+
+          gh pr comment ${{ github.event.pull_request.number }} --body-file pr_comment.txt

--- a/scripts/ai-pr-filler.mjs
+++ b/scripts/ai-pr-filler.mjs
@@ -35,7 +35,7 @@ function renderTemplate(template, sections) {
 
     const value = safe(sections[key]);
 
-    result = result.replace(regex, `## ${header}\n${value}\n`);
+    result = result.replace(regex, () => `## ${header}\n${value}\n`);
   }
 
   return result.trim() + "\n";
@@ -140,7 +140,7 @@ ${diff}
     }
 
     const finalBody = renderTemplate(template, sections);
-    if (finalBody.trim() === template.trim()) {
+    if (finalBody.trim() === renderTemplate(template, {}).trim()) {
       process.exit(0);
     }
 

--- a/scripts/ai-pr-filler.mjs
+++ b/scripts/ai-pr-filler.mjs
@@ -10,24 +10,7 @@ const TEMPLATE_PATH = ".github/pull_request_template.md";
 const PR_TITLE = process.env.PR_TITLE || "N/A";
 const COMMITS = process.env.COMMITS || "N/A";
 
-function normalizeSteps(text) {
-  if (!text || typeof text !== "string") return text;
-
-  const trimmed = text.trim();
-
-  if (!trimmed) return trimmed;
-
-  // already multiline
-  if (trimmed.includes("\n")) return trimmed;
-
-  // split "1. a 2. b 3. c"
-  const parts = trimmed.split(/\s(?=\d+\.)/g);
-
-  if (parts.length === 1) return trimmed;
-
-  return parts.map((p) => p.trim()).join("\n");
-}
-
+const safe = (v) => (typeof v === "string" && v.trim() ? v.trim() : "N/A");
 function renderTemplate(template, sections) {
   let result = template;
 
@@ -50,12 +33,9 @@ function renderTemplate(template, sections) {
       `##\\s*${escapedHeader}[\\s\\S]*?(?=\\r?\\n## |$)`
     );
 
-    const rawValue = sections[key] ?? "N/A";
+    const value = safe(sections[key]);
 
-    const value = key === "manualTest" ? normalizeSteps(rawValue) : rawValue;
-
-    // result = result.replace(regex, `## ${header}\n${value}\n`);
-    result = result.replace(regex, `## ${header}\n${sections[key]}\n`);
+    result = result.replace(regex, `## ${header}\n${value}\n`);
   }
 
   return result.trim() + "\n";
@@ -160,6 +140,9 @@ ${diff}
     }
 
     const finalBody = renderTemplate(template, sections);
+    if (finalBody.trim() === template.trim()) {
+      process.exit(0);
+    }
 
     console.log(finalBody);
   } catch (error) {


### PR DESCRIPTION
## What does this PR do?
This diff modifies the AI PR filler GitHub Action to prevent overwriting human-edited PR descriptions and to instead post suggestions as comments. It introduces a check to skip AI updates if the PR body differs from the default template. The associated Node.js script is updated to remove a `normalizeSteps` function, simplify value handling, and exit early if the generated PR body is identical to the template, preventing empty suggestions.

## Description of Task to be completed?
The primary task is to improve the user experience of the AI PR filler by making it non-destructive. Previously, the AI would overwrite the PR description, potentially losing human edits. By posting suggestions as comments, the AI becomes a helpful assistant rather than an intrusive one. It also refines the logic for generating and posting PR descriptions, ensuring that the AI only acts when it can provide a meaningful suggestion or when a human hasn't already modified the description.

## How should this be manually tested?
1. Create a new branch and push some commits. Open a Pull Request.
2. Verify that the AI posts a comment with a 'Suggested PR description'.
3. Manually edit the PR description (e.g., add a line).
4. Push another commit to the same branch.
5. Verify that the AI does NOT post another comment (it should skip due to human edits).
6. Revert the manual edits so the PR body matches the template again.
7. Push another commit.
8. Verify that the AI again posts a comment with a suggestion.
9. Create a PR with minimal commits or content that might result in the AI generating a body identical to the template. Verify that the AI does not post a comment in this scenario (due to the early exit in `ai-pr-filler.mjs`).

## What are the relevant Jira board stories?
[HOM-181](https://wasiu-dev.atlassian.net/jira/software/projects/HOM/boards/2?selectedIssue=HOM-181)

## Any background context you want to provide?
This project uses a GitHub Action that leverages AI to automatically generate Pull Request descriptions. The previous implementation would directly modify the PR body, which could lead to accidental overwrites of human-authored content. This change transforms the AI's role from an automatic updater to a helpful suggester, enhancing developer workflow by providing AI-generated content without risking data loss. The removal of `normalizeSteps` and simplification of value handling in the script suggest an evolution in how template sections are populated.

## Questions
1. What was the specific issue or limitation with the `normalizeSteps` function that led to its removal? Is the new `safe` function considered robust enough for all potential section values?
2. Are there any edge cases considered for the `diff` command used to check for human edits, especially with different operating system line endings (though `tr -d '\r'` attempts to normalize)?
3. What is the intended behaviour if the AI previously generated a PR body that a human then modifies slightly? The current logic would skip updates; is there consideration for re-engaging the AI if the human's edit is minor, or only if the body is fully reverted to the template?


[HOM-181]: https://wasiu-dev.atlassian.net/browse/HOM-181?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ